### PR TITLE
fix: Remove ticks strategy to handle UNIX signals.

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -48,7 +48,6 @@ class Worker implements LoggerAwareInterface
         $this->sessionId = ($sessionId !== null) ? $sessionId : uniqid();
 
         if (function_exists('pcntl_signal')) {
-            declare (ticks = 1);
             pcntl_signal(SIGTERM, [$this, 'signalHandler']);
             pcntl_signal(SIGINT, [$this, 'signalHandler']);
             pcntl_signal(SIGHUP, [$this, 'signalHandler']);


### PR DESCRIPTION
Hello,

We are using `ticks` strategy to handle UNIX signal.
As far as I understand, our signal handler will be called each code instruction and then perform what we want it to do.
Unfortunately it is not what we want to do in case of gracefully stop a process for example.
Since PHP 5.3 it is very discouraged to use `ticks`. Instead we should use `pcntl_signal_dispatch` which allow us to perform our signal when ever we want.
In this scenario we should let the client defines when it wants to dispatch the signal.

This PR is a BC break.

Relevant sources: [here](http://php.net/manual/fr/function.pcntl-signal.php#92803) or [here (in french)](https://jolicode.com/blog/les-signaux-posix-et-php)